### PR TITLE
Speedup parsing 2.6x

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -265,34 +265,39 @@ func lexContent(l *Lexer) lexFunc {
 		} else {
 			return l.errorf("Unclosed raw block")
 		}
-	} else if l.isString(escapedEscapedOpenMustache) {
-		// \\{{
+	} else {
+		switch l.peek() {
+		case '\\':
+			if l.isString(escapedEscapedOpenMustache) {
+				// \\{{
 
-		// emit content with only one escaped escape
-		l.next()
-		l.emitContent()
+				// emit content with only one escaped escape
+				l.next()
+				l.emitContent()
 
-		// ignore second escaped escape
-		l.next()
-		l.ignore()
+				// ignore second escaped escape
+				l.next()
+				l.ignore()
 
-		next = lexContent
-	} else if l.isString(escapedOpenMustache) {
-		// \{{
-		next = lexEscapedOpenMustache
-	} else if l.isString(openCommentDash) || l.isString(openCommentStripDash) {
-		// {{!--
-		l.closeComment = rCloseCommentDash
-
-		next = lexComment
-	} else if l.isString(openComment) || l.isString(openCommentStrip) {
-		// {{!
-		l.closeComment = rCloseComment
-
-		next = lexComment
-	} else if l.isString(openMustache) {
-		// {{
-		next = lexOpenMustache
+				next = lexContent
+			} else if l.isString(escapedOpenMustache) {
+				// \{{
+				next = lexEscapedOpenMustache
+			}
+		case '{':
+			if l.isString(openCommentDash) || l.isString(openCommentStripDash) {
+				// {{!--
+				l.closeComment = rCloseCommentDash
+				next = lexComment
+			} else if l.isString(openComment) || l.isString(openCommentStrip) {
+				// {{!
+				l.closeComment = rCloseComment
+				next = lexComment
+			} else if l.isString(openMustache) {
+				// {{
+				next = lexOpenMustache
+			}
+		}
 	}
 
 	if next != nil {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -21,6 +21,10 @@ const (
 	closeMustache               = "}}"
 	closeStripMustache          = "~}}"
 	closeUnescapedStripMustache = "}~}}"
+	openComment                 = "{{!"
+	openCommentStrip            = "{{~!"
+	openCommentDash             = "{{!--"
+	openCommentStripDash        = "{{~!--"
 )
 
 const eof = -1
@@ -74,11 +78,9 @@ var (
 	rOpen            = regexp.MustCompile(`^\{\{~?&?`)
 	rClose           = regexp.MustCompile(`^~?\}\}`)
 	rOpenBlockParams = regexp.MustCompile(`^as\s+\|`)
-	// {{!--  ... --}}
-	rOpenCommentDash  = regexp.MustCompile(`^\{\{~?!--\s*`)
+	// --}} or --~}}
 	rCloseCommentDash = regexp.MustCompile(`^\s*--~?\}\}`)
-	// {{! ... }}
-	rOpenComment  = regexp.MustCompile(`^\{\{~?!\s*`)
+	// }} or ~}}
 	rCloseComment = regexp.MustCompile(`^\s*~?\}\}`)
 )
 
@@ -278,12 +280,12 @@ func lexContent(l *Lexer) lexFunc {
 	} else if l.isString(escapedOpenMustache) {
 		// \{{
 		next = lexEscapedOpenMustache
-	} else if str := l.findRegexp(rOpenCommentDash); str != "" {
+	} else if l.isString(openCommentDash) || l.isString(openCommentStripDash) {
 		// {{!--
 		l.closeComment = rCloseCommentDash
 
 		next = lexComment
-	} else if str := l.findRegexp(rOpenComment); str != "" {
+	} else if l.isString(openComment) || l.isString(openCommentStrip) {
 		// {{!
 		l.closeComment = rCloseComment
 


### PR DESCRIPTION
Hello @imantung, I am using your library in https://github.com/xvello/letsblockit and noticed that, although the rendering performance is great, the parsing speed can be improved.. A quick profile, using [the 11 handlebar files in my project](https://github.com/xvello/letsblockit/tree/main/data/pages) showed some quick-wins that I want to contribute back.

This first PR improves `lexContent` (the hottest function in my initial profiling), resulting in a **2.6x speed increase** on my (admitedly small) test corpus. I'd be happy to re-run the parsing benchmark with another corpus if you can provide one.

## Profiles 
Here are PDF renderings of [initial profiling](https://github.com/imantung/mario/files/7597897/cpu_orig.pdf) and [profiling of this branch](https://github.com/imantung/mario/files/7597898/cpu_patched.pdf). There are more branches to optimize, but I wanted to start with an easy PR.

## Benchmarks

#### Before

```
± go test ./bench/ -bench=. -benchtime=30s -benchmem -cpuprofile cpu.prof
goos: linux
goarch: amd64
pkg: github.com/imantung/mario/bench
cpu: AMD Ryzen 5 PRO 3500U w/ Radeon Vega Mobile Gfx
BenchmarkPageLoad-8         1220          31088188 ns/op          434625 B/op       6324 allocs/op
BenchmarkPageLoad-8         1213          31095209 ns/op          434913 B/op       6324 allocs/op
BenchmarkPageLoad-8         1222          30983005 ns/op          433669 B/op       6323 allocs/op
```
#### After replacing the regexp with `isString`

```
BenchmarkPageLoad-8         2740          13910230 ns/op          431941 B/op       6323 allocs/op
BenchmarkPageLoad-8         2754          13988925 ns/op          431047 B/op       6322 allocs/op
```
#### After adding peek
```
BenchmarkPageLoad-8         3288          11679414 ns/op          428415 B/op       6322 allocs/op
BenchmarkPageLoad-8         3526          11795542 ns/op          430295 B/op       6323 allocs/op
BenchmarkPageLoad-8         4036          11716324 ns/op          428726 B/op       6322 allocs/op
```